### PR TITLE
Show version in html and pushing env variables

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,2 @@
+# Getting app version from package.json
+APP_VERSION=$npm_package_version

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,7 @@ yarn-error.log*
 pnpm-debug.log*
 
 # environment variables
-.env*
+.env*.local
 
 # Created by https://www.toptal.com/developers/gitignore/api/windows,macos
 # Edit at https://www.toptal.com/developers/gitignore?templates=windows,macos

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "irian-personal-page",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "irian-personal-page",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "hasInstallScript": true,
       "dependencies": {
         "@astrojs/check": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "irian-personal-page",
   "type": "module",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -15,6 +15,7 @@ export interface Props {
 const {title} = Astro.props;
 const locale = getLangFromUrl(Astro.url);
 const baseUrl = import.meta.env.BASE_URL;
+const appVersion = import.meta.env.APP_VERSION ?? 'unknown';
 ---
 
 <!doctype html>
@@ -48,6 +49,7 @@ const baseUrl = import.meta.env.BASE_URL;
     <meta name="msapplication-TileColor" content="#da532c" />
     <meta name="theme-color" content="#ffffff" />
     <meta name="generator" content={Astro.generator} />
+    <meta name="version" content={appVersion} />
     <title>{title}</title>
   </head>
   <body>


### PR DESCRIPTION
## Changes
- Pushing .env* but not .env*.local variable files as [Vite docs say](https://vitejs.dev/guide/env-and-mode.html#env-files)
- Showing app version on a `<meta>` HTML tag on the `<head>`
- Bumped to version 1.1.1