### PR TITLE
Fix double gallery issue

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "irian-personal-page",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "irian-personal-page",
-      "version": "1.1.1",
+      "version": "1.1.2",
       "hasInstallScript": true,
       "dependencies": {
         "@astrojs/check": "^0.3.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "irian-personal-page",
   "type": "module",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/src/components/website/ProjectsSection/ProjectsSection.astro
+++ b/src/components/website/ProjectsSection/ProjectsSection.astro
@@ -216,8 +216,12 @@ const t = useTranslations(locale);
     });
 
     // Removing the elements that don't have any projects as children
-    document.querySelectorAll('lightgallery-pressable:empty').forEach((lg) => {
-      lg.remove();
+    // Seems removing a node doesn't remove the instance so the loop
+    // doesn't break, so let's go!
+    document.querySelectorAll('lightgallery-pressable').forEach((lg) => {
+      if (lg.children.length === 0) {
+        lg.remove();
+      }
     });
   })();
 </script>


### PR DESCRIPTION
There was an issue where images were overlapping when opening an URL pertaining to a gallery like https://irian.codes/en/#lg=project-0&slide=0 . This was caused because an improper deletion of the unused `<lightgallery-pressable` empty nodes as the CSS `:empty` selector doesn't detect elements that have text node in them and for whatever reason Astro adds an empty text node in some empty nodes. So now with JS using `.children` it works!