### PR TITLE
Fix GitHub ribbon bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "irian-personal-page",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "irian-personal-page",
-      "version": "1.5.0",
+      "version": "1.5.1",
       "hasInstallScript": true,
       "dependencies": {
         "@astrojs/check": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "irian-personal-page",
   "type": "module",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/src/components/website/ForkGithubRibbon.astro
+++ b/src/components/website/ForkGithubRibbon.astro
@@ -24,10 +24,12 @@
     }
 
     if (newState === 'show') {
+      forkongithubElement.style.visibility = 'visible';
       forkongithubElement.style.opacity = '1';
     }
 
     if (newState === 'hide') {
+      forkongithubElement.style.visibility = 'hidden';
       forkongithubElement.style.opacity = '0';
     }
   }
@@ -79,6 +81,7 @@
   #forkongithub {
     position: fixed;
     display: block;
+    visibility: hidden;
     opacity: 0;
     bottom: -4.5rem;
     right: -8.5rem;
@@ -87,7 +90,7 @@
     height: 12.5rem;
     z-index: 9000;
     transform: rotate(315deg);
-    transition: 0.5s;
+    transition: opacity 0.5s;
   }
   a {
     top: 4rem;


### PR DESCRIPTION
Made Github ribbon only clickable when visible. Before the hyperlink was working when it wasn't visible and this shouldn't happen.

## Changes
- Transitioning only opacity
- Hiding and showing the ribbon instantly via Javascript