### PR TITLE
Refactored React language hooks used in resume

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "irian-personal-page",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "irian-personal-page",
-      "version": "1.10.0",
+      "version": "1.10.1",
       "hasInstallScript": true,
       "dependencies": {
         "@astrojs/check": "^0.5.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "irian-personal-page",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "irian-personal-page",
-      "version": "1.10.1",
+      "version": "1.10.2",
       "hasInstallScript": true,
       "dependencies": {
         "@astrojs/check": "^0.5.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "irian-personal-page",
   "type": "module",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "irian-personal-page",
   "type": "module",
-  "version": "1.10.1",
+  "version": "1.10.2",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/src/components/cv/CvPdf.tsx
+++ b/src/components/cv/CvPdf.tsx
@@ -1,6 +1,7 @@
 import {Document, Page, StyleSheet} from '@react-pdf/renderer';
 import {createContext} from 'react';
 import {cvData} from '../../data/cv/CvData';
+import type {CvData} from '../../data/cv/types/CvData';
 import type {LanguageTag} from '../../i18n/i18n';
 import {useTranslations} from '../../i18n/i18nUtils';
 import {CvContent} from './content';
@@ -11,7 +12,7 @@ registerFonts();
 
 type LocalizedDataUtils = {
   t: ReturnType<typeof useTranslations>;
-  data: (typeof cvData.data)[number];
+  data: CvData;
 };
 
 // @ts-expect-error value not initialized but it doesn't need to be
@@ -20,7 +21,7 @@ export const LocalizedDataContext = createContext<LocalizedDataUtils>();
 export function CvPdf(langTag: LanguageTag) {
   const languageContextValue = {
     t: useTranslations(langTag),
-    data: cvData.data.find((entry) => entry.langTag === langTag)!,
+    data: cvData.data.get(langTag)!,
   };
 
   return (

--- a/src/components/cv/CvPdf.tsx
+++ b/src/components/cv/CvPdf.tsx
@@ -1,22 +1,36 @@
 import {Document, Page, StyleSheet} from '@react-pdf/renderer';
 import {createContext} from 'react';
+import {cvData} from '../../data/cv/CvData';
 import type {LanguageTag} from '../../i18n/i18n';
+import {useTranslations} from '../../i18n/i18nUtils';
 import {CvContent} from './content';
 import {cvStyles} from './content/styles/CvStyles';
 import {registerFonts} from './utils/Fonts';
 
 registerFonts();
-export const LanguageContext = createContext<LanguageTag>('en');
+
+type LocalizedDataUtils = {
+  t: ReturnType<typeof useTranslations>;
+  data: (typeof cvData.data)[number];
+};
+
+// @ts-expect-error value not initialized but it doesn't need to be
+export const LocalizedDataContext = createContext<LocalizedDataUtils>();
 
 export function CvPdf(langTag: LanguageTag) {
+  const languageContextValue = {
+    t: useTranslations(langTag),
+    data: cvData.data.find((entry) => entry.langTag === langTag)!,
+  };
+
   return (
-    <LanguageContext.Provider value={langTag}>
+    <LocalizedDataContext.Provider value={languageContextValue}>
       <Document>
         <Page size="A4" style={styles.page}>
           <CvContent />
         </Page>
       </Document>
-    </LanguageContext.Provider>
+    </LocalizedDataContext.Provider>
   );
 }
 

--- a/src/components/cv/content/header/ContactDetail.tsx
+++ b/src/components/cv/content/header/ContactDetail.tsx
@@ -1,9 +1,7 @@
 import {Link, StyleSheet, Text, View} from '@react-pdf/renderer';
 import {useContext} from 'react';
-import {cvData} from '../../../../data/cv/CvData';
-import {useTranslations} from '../../../../i18n/i18nUtils';
 import {splitStringAtLastOccurrence} from '../../../../utils/StringUtils';
-import {LanguageContext} from '../../CvPdf';
+import {LocalizedDataContext} from '../../CvPdf';
 import {getPublicFolderURL} from '../../utils/URL';
 import {headerStyles} from './styles/HeaderStyles';
 
@@ -20,9 +18,7 @@ type ContactDetailProps = {
 };
 
 export const ContactDetail = (props: ContactDetailProps) => {
-  const langTag = useContext(LanguageContext);
-  const t = useTranslations(langTag);
-  const data = cvData.data.find((entry) => entry.langTag === langTag)!;
+  const {t, data} = useContext(LocalizedDataContext);
 
   const imageUrl =
     getPublicFolderURL() + '/assets/images/cv/icons/' + props.type + '.png';

--- a/src/components/cv/content/header/ContactDetail.tsx
+++ b/src/components/cv/content/header/ContactDetail.tsx
@@ -52,7 +52,7 @@ export const ContactDetail = (props: ContactDetailProps) => {
         return 'tel:' + content;
 
       case 'location':
-        const mapsUrl = data.content.header.locationMapsUrl;
+        const mapsUrl = data.header.locationMapsUrl;
 
         return mapsUrl ?? '#';
 
@@ -84,7 +84,7 @@ export const ContactDetail = (props: ContactDetailProps) => {
         <Text style={styles.label}>
           {t(`cv.header.contact-details.${props.type}.title`)}
         </Text>
-        {getLinkOrTextElement(data.content.header[props.type])}
+        {getLinkOrTextElement(data.header[props.type])}
       </View>
     </View>
   );

--- a/src/components/cv/content/header/Header.tsx
+++ b/src/components/cv/content/header/Header.tsx
@@ -1,15 +1,13 @@
 import {Image, StyleSheet, Text, View} from '@react-pdf/renderer';
 import {useContext} from 'react';
-import {cvData} from '../../../../data/cv/CvData';
-import {LanguageContext} from '../../CvPdf';
+import {LocalizedDataContext} from '../../CvPdf';
 import {AboutMeSection} from '../sections/AboutMeSection';
 import {cvStyles} from '../styles/CvStyles';
 import {ContactDetail} from './ContactDetail';
 import {headerStyles} from './styles/HeaderStyles';
 
 export const Header = () => {
-  const langTag = useContext(LanguageContext);
-  const data = cvData.data.find((entry) => entry.langTag === langTag)!;
+  const {t, data} = useContext(LocalizedDataContext);
 
   const ApplicantImageComponent = () => {
     if (data.content.header.photoSrc.length > 0) {

--- a/src/components/cv/content/header/Header.tsx
+++ b/src/components/cv/content/header/Header.tsx
@@ -10,13 +10,8 @@ export const Header = () => {
   const {t, data} = useContext(LocalizedDataContext);
 
   const ApplicantImageComponent = () => {
-    if (data.content.header.photoSrc.length > 0) {
-      return (
-        <Image
-          src={data.content.header.photoSrc}
-          style={styles.applicantPhoto}
-        />
-      );
+    if (data.header.photoSrc.length > 0) {
+      return <Image src={data.header.photoSrc} style={styles.applicantPhoto} />;
     } else {
       return null;
     }
@@ -30,9 +25,9 @@ export const Header = () => {
 
           <View>
             <Text style={styles.name}>
-              {data.content.header.name + ' ' + data.content.header.surnames}
+              {data.header.name + ' ' + data.header.surnames}
             </Text>
-            <Text style={styles.position}>{data.content.header.position}</Text>
+            <Text style={styles.position}>{data.header.position}</Text>
           </View>
         </View>
         <AboutMeSection />

--- a/src/components/cv/content/sections/AboutMeSection.tsx
+++ b/src/components/cv/content/sections/AboutMeSection.tsx
@@ -1,15 +1,13 @@
 import {StyleSheet, Text, View} from '@react-pdf/renderer';
 import React, {useContext} from 'react';
-import {cvData} from '../../../../data/cv/CvData';
-import {LanguageContext} from '../../CvPdf';
+import {LocalizedDataContext} from '../../CvPdf';
 import {headerStyles} from '../header/styles/HeaderStyles';
 import {cvStyles} from '../styles/CvStyles';
 
 type AboutMeSectionProps = {containerStyle?: any};
 
 export const AboutMeSection = (props: AboutMeSectionProps) => {
-  const langTag = useContext(LanguageContext);
-  const data = cvData.data.find((entry) => entry.langTag === langTag)!;
+  const {t, data} = useContext(LocalizedDataContext);
 
   return (
     <View style={props.containerStyle}>

--- a/src/components/cv/content/sections/AboutMeSection.tsx
+++ b/src/components/cv/content/sections/AboutMeSection.tsx
@@ -11,7 +11,7 @@ export const AboutMeSection = (props: AboutMeSectionProps) => {
 
   return (
     <View style={props.containerStyle}>
-      {data.content.aboutSection.lines.map((line, index, linesArr) => (
+      {data.aboutSection.lines.map((line, index, linesArr) => (
         <React.Fragment key={line.substring(0, 10)}>
           <Text style={styles.content}>{line}</Text>
 

--- a/src/components/cv/content/sections/EducationSection.tsx
+++ b/src/components/cv/content/sections/EducationSection.tsx
@@ -14,7 +14,7 @@ export const EducationSection = (props: EducationSectionProps) => {
   return (
     <View style={props.containerStyle}>
       <Text style={styles.h1}>{t('cv.body.section.title.education')}</Text>
-      {data.content.educationSection.entries
+      {data.educationSection.entries
         .filter((entry) => !entry.hidden)
         .sort((a, b) => (a.id < b.id ? 1 : -1))
         .map((entry) => (

--- a/src/components/cv/content/sections/EducationSection.tsx
+++ b/src/components/cv/content/sections/EducationSection.tsx
@@ -1,8 +1,6 @@
 import {StyleSheet, Text, View} from '@react-pdf/renderer';
 import {useContext} from 'react';
-import {cvData} from '../../../../data/cv/CvData';
-import {useTranslations} from '../../../../i18n/i18nUtils';
-import {LanguageContext} from '../../CvPdf';
+import {LocalizedDataContext} from '../../CvPdf';
 import {cvStyles} from '../styles/CvStyles';
 import {SectionEntry} from './components/SectionEntry';
 
@@ -11,9 +9,7 @@ type EducationSectionProps = {
 };
 
 export const EducationSection = (props: EducationSectionProps) => {
-  const langTag = useContext(LanguageContext);
-  const t = useTranslations(langTag);
-  const data = cvData.data.find((entry) => entry.langTag === langTag)!;
+  const {t, data} = useContext(LocalizedDataContext);
 
   return (
     <View style={props.containerStyle}>

--- a/src/components/cv/content/sections/OtherSection.tsx
+++ b/src/components/cv/content/sections/OtherSection.tsx
@@ -11,7 +11,7 @@ export const OtherSection = (props: OtherSectionProps) => {
   return (
     <View style={props.containerStyle}>
       <Text style={styles.h1}>{t('cv.body.section.title.other')}</Text>
-      {data.content.otherSection.lines.map((line) => (
+      {data.otherSection.lines.map((line) => (
         <Text key={line.substring(0, 10)} style={styles.content}>
           {'- ' + line}
         </Text>

--- a/src/components/cv/content/sections/OtherSection.tsx
+++ b/src/components/cv/content/sections/OtherSection.tsx
@@ -1,16 +1,12 @@
 import {StyleSheet, Text, View} from '@react-pdf/renderer';
 import {useContext} from 'react';
-import {cvData} from '../../../../data/cv/CvData';
-import {useTranslations} from '../../../../i18n/i18nUtils';
-import {LanguageContext} from '../../CvPdf';
+import {LocalizedDataContext} from '../../CvPdf';
 import {cvStyles} from '../styles/CvStyles';
 
 type OtherSectionProps = {containerStyle?: any};
 
 export const OtherSection = (props: OtherSectionProps) => {
-  const langTag = useContext(LanguageContext);
-  const t = useTranslations(langTag);
-  const data = cvData.data.find((entry) => entry.langTag === langTag)!;
+  const {t, data} = useContext(LocalizedDataContext);
 
   return (
     <View style={props.containerStyle}>

--- a/src/components/cv/content/sections/ProjectsSection.tsx
+++ b/src/components/cv/content/sections/ProjectsSection.tsx
@@ -1,8 +1,6 @@
 import {StyleSheet, Text, View} from '@react-pdf/renderer';
 import {useContext} from 'react';
-import {cvData} from '../../../../data/cv/CvData';
-import {useTranslations} from '../../../../i18n/i18nUtils';
-import {LanguageContext} from '../../CvPdf';
+import {LocalizedDataContext} from '../../CvPdf';
 import {cvStyles} from '../styles/CvStyles';
 import {ProjectSectionEntry} from './components/ProjectSectionEntry';
 
@@ -11,9 +9,7 @@ type ProjectSectionProps = {
 };
 
 export const ProjectsSection = (props: ProjectSectionProps) => {
-  const langTag = useContext(LanguageContext);
-  const t = useTranslations(langTag);
-  const data = cvData.data.find((entry) => entry.langTag === langTag)!;
+  const {t, data} = useContext(LocalizedDataContext);
 
   return (
     <View style={props.containerStyle}>

--- a/src/components/cv/content/sections/ProjectsSection.tsx
+++ b/src/components/cv/content/sections/ProjectsSection.tsx
@@ -14,7 +14,7 @@ export const ProjectsSection = (props: ProjectSectionProps) => {
   return (
     <View style={props.containerStyle}>
       <Text style={styles.h1}>{t('cv.body.section.title.projects')}</Text>
-      {data.content.projectSection.entries.map((entry) => (
+      {data.projectSection.entries.map((entry) => (
         <ProjectSectionEntry
           key={entry.id}
           project={entry}

--- a/src/components/cv/content/sections/SkillsSection.tsx
+++ b/src/components/cv/content/sections/SkillsSection.tsx
@@ -1,9 +1,7 @@
 import {StyleSheet, Text, View} from '@react-pdf/renderer';
 import Color from 'colorjs.io';
 import {useContext, useMemo} from 'react';
-import {cvData} from '../../../../data/cv/CvData';
-import {useTranslations} from '../../../../i18n/i18nUtils';
-import {LanguageContext} from '../../CvPdf';
+import {LocalizedDataContext} from '../../CvPdf';
 import {cvStyles} from '../styles/CvStyles';
 import {SkillChip} from './components/SkillChip';
 
@@ -12,9 +10,7 @@ type SkillsSectionProps = {
 };
 
 export const SkillsSection = (props: SkillsSectionProps) => {
-  const langTag = useContext(LanguageContext);
-  const t = useTranslations(langTag);
-  const data = cvData.data.find((entry) => entry.langTag === langTag)!;
+  const {t, data} = useContext(LocalizedDataContext);
 
   const skillChipBaseColor = useMemo(
     () => new Color(cvStyles.colors.secondary),

--- a/src/components/cv/content/sections/SkillsSection.tsx
+++ b/src/components/cv/content/sections/SkillsSection.tsx
@@ -62,7 +62,7 @@ export const SkillsSection = (props: SkillsSectionProps) => {
         <SkillsLegend />
       </View>
       <View style={{flexDirection: 'row', flexWrap: 'wrap'}}>
-        {data.content.skillsSection.skills
+        {data.skillsSection.skills
           .filter((skill) => !skill.hidden)
           .map((skill) => (
             <SkillChip

--- a/src/components/cv/content/sections/WorkExperienceSection.tsx
+++ b/src/components/cv/content/sections/WorkExperienceSection.tsx
@@ -1,8 +1,6 @@
 import {StyleSheet, Text, View} from '@react-pdf/renderer';
 import {useContext} from 'react';
-import {cvData} from '../../../../data/cv/CvData';
-import {useTranslations} from '../../../../i18n/i18nUtils';
-import {LanguageContext} from '../../CvPdf';
+import {LocalizedDataContext} from '../../CvPdf';
 import {cvStyles} from '../styles/CvStyles';
 import {SectionEntry} from './components/SectionEntry';
 
@@ -11,9 +9,7 @@ type WorkExperienceSectionProps = {
 };
 
 export const WorkExperienceSection = (props: WorkExperienceSectionProps) => {
-  const langTag = useContext(LanguageContext);
-  const t = useTranslations(langTag);
-  const data = cvData.data.find((entry) => entry.langTag === langTag)!;
+  const {t, data} = useContext(LocalizedDataContext);
 
   return (
     <View style={props.containerStyle}>

--- a/src/components/cv/content/sections/WorkExperienceSection.tsx
+++ b/src/components/cv/content/sections/WorkExperienceSection.tsx
@@ -16,7 +16,7 @@ export const WorkExperienceSection = (props: WorkExperienceSectionProps) => {
       <Text style={styles.h1}>
         {t('cv.body.section.title.work-experience')}
       </Text>
-      {data.content.workExperienceSection.entries
+      {data.workExperienceSection.entries
         .filter((entry) => !entry.hidden)
         .sort((a, b) => (a.id < b.id ? 1 : -1))
         .map((entry) => (

--- a/src/data/cv/CvData.ts
+++ b/src/data/cv/CvData.ts
@@ -1,20 +1,13 @@
+import type {LanguageTag} from '../../i18n/i18n';
 import {cvData_ca} from './CvData-ca';
 import {cvData_en} from './CvData-en';
 import {cvData_es} from './CvData-es';
+import type {CvData} from './types/CvData';
 
-export const cvData = {
-  data: [
-    {
-      langTag: 'en',
-      content: cvData_en,
-    },
-    {
-      langTag: 'es',
-      content: cvData_es,
-    },
-    {
-      langTag: 'ca',
-      content: cvData_ca,
-    },
-  ],
+export const cvData: {data: Map<LanguageTag, CvData>} = {
+  data: new Map([
+    ['en', cvData_en],
+    ['es', cvData_es],
+    ['ca', cvData_ca],
+  ]),
 };


### PR DESCRIPTION
Refactored React language hooks used in resume so they were easier to consume and avoid code repetition.

## Changes
### v1.10.1
- Refactored code to make it better

### v1.10.2
- Refactored CvData data structure because the Map reflects better the function of this object. It's not an entity, it's a read only data repository so Map is technically more appropiate for this.
- Simplified code to access data in several places.