### PR TITLE
Move resume button

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,5 +1,13 @@
 {
   "extends": ["stylelint-config-standard", "stylelint-config-html"],
+  "overrides": [
+    {
+      "files": ["*.astro"],
+      "rules": {
+        "custom-property-pattern": null
+      }
+    }
+  ],
   "rules": {
     "property-no-vendor-prefix": true,
     "shorthand-property-no-redundant-values": null,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "irian-personal-page",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "irian-personal-page",
-      "version": "1.13.1",
+      "version": "1.14.0",
       "hasInstallScript": true,
       "dependencies": {
         "@astrojs/check": "^0.5.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "irian-personal-page",
   "type": "module",
-  "version": "1.13.1",
+  "version": "1.14.0",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/src/components/website/CvButton.astro
+++ b/src/components/website/CvButton.astro
@@ -24,41 +24,66 @@ const buttonUrl = (() => {
 </div>
 
 <script>
-  const cvButtons = Array.from(document.getElementsByClassName('cv-button'));
+  (function rippleClickAnimation() {
+    const cvButtons = Array.from(document.getElementsByClassName('cv-button'));
 
-  cvButtons.forEach((btn) => {
-    const rippleSource = btn.querySelector('.ripple-source') as
-      | HTMLElement
-      | undefined;
+    cvButtons.forEach((btn) => {
+      const rippleSource = btn.querySelector('.ripple-source') as
+        | HTMLElement
+        | undefined;
 
-    const rippleContainer = btn.querySelector('.ripple-container') as
-      | HTMLElement
-      | undefined;
+      const rippleContainer = btn.querySelector('.ripple-container') as
+        | HTMLElement
+        | undefined;
 
-    if (!rippleSource || !rippleContainer) {
-      return;
-    }
+      if (!rippleSource || !rippleContainer) {
+        return;
+      }
 
-    btn.addEventListener('click', (event) => {
-      // Remove the animation in case the user clicks and it's still playing
-      rippleContainer.classList.remove('ripple-animation-on');
-      rippleSource?.classList.remove('ripple-animation-on');
+      btn.addEventListener('click', (event) => {
+        // Remove the animation in case the user clicks and it's still playing
+        rippleContainer.classList.remove('ripple-animation-on');
+        rippleSource?.classList.remove('ripple-animation-on');
 
-      const {pageX, pageY} = event as MouseEvent;
-      const rect = btn.getBoundingClientRect();
+        const {pageX, pageY} = event as MouseEvent;
+        const rect = btn.getBoundingClientRect();
 
-      rippleSource.style.top = `${pageY - rect.top}px`;
-      rippleSource.style.left = `${pageX - rect.left}px`;
+        rippleSource.style.top = `${pageY - rect.top}px`;
+        rippleSource.style.left = `${pageX - rect.left}px`;
 
-      rippleContainer?.classList.add('ripple-animation-on');
-      rippleSource?.classList.add('ripple-animation-on');
+        rippleContainer?.classList.add('ripple-animation-on');
+        rippleSource?.classList.add('ripple-animation-on');
+      });
+
+      rippleSource.addEventListener('animationend', () => {
+        rippleContainer.classList.remove('ripple-animation-on');
+        rippleSource?.classList.remove('ripple-animation-on');
+      });
     });
+  })();
 
-    rippleSource.addEventListener('animationend', () => {
-      rippleContainer.classList.remove('ripple-animation-on');
-      rippleSource?.classList.remove('ripple-animation-on');
+  (function fluidScaling() {
+    const cvButtons = Array.from(document.getElementsByClassName('cv-button'));
+
+    const minWidth = 700;
+    const maxWidth = 1080;
+    const minScaleValue = 1;
+    const maxScaleValue = 1.5;
+
+    const mappingScaleFactor =
+      (maxScaleValue - minScaleValue) / (maxWidth - minWidth);
+
+    const offset = -minWidth * mappingScaleFactor + minScaleValue;
+
+    const scaleValue = Math.max(
+      Math.min(window.innerWidth * mappingScaleFactor + offset, maxScaleValue),
+      minScaleValue
+    );
+
+    cvButtons.forEach((btn) => {
+      (btn as HTMLButtonElement).style.transform = `scale(${scaleValue})`;
     });
-  });
+  })();
 </script>
 
 <style>
@@ -103,7 +128,7 @@ const buttonUrl = (() => {
   }
 
   @keyframes shadow-animation {
-
+    
     0% {
       transform: scale(1);
     }

--- a/src/components/website/CvButton.astro
+++ b/src/components/website/CvButton.astro
@@ -16,31 +16,9 @@ const buttonUrl = (() => {
 
 <div class="cv-button">
   <a href={buttonUrl}>
-    <WebsiteButton label={t('website.home.top-section.cv-button.label')} />
+    <WebsiteButton
+      label={t('website.home.top-section.cv-button.label')}
+      fluidMaxFontSizeInRem={2}
+    />
   </a>
 </div>
-
-<script>
-  import {mapRangeOntoAnother} from '../../utils/MathUtils';
-
-  (function fluidScaling() {
-    const cvButtons = Array.from(document.getElementsByClassName('cv-button'));
-
-    const minWidth = 700;
-    const maxWidth = 1080;
-    const minScaleValue = 1;
-    const maxScaleValue = 1.5;
-
-    cvButtons.forEach((btn) => {
-      (btn as HTMLButtonElement).style.transform = `scale(${mapRangeOntoAnother(
-        {
-          valueA: window.innerWidth,
-          minA: minWidth,
-          maxA: maxWidth,
-          minB: minScaleValue,
-          maxB: maxScaleValue,
-        }
-      )})`;
-    });
-  })();
-</script>

--- a/src/components/website/CvButton.astro
+++ b/src/components/website/CvButton.astro
@@ -24,6 +24,8 @@ const buttonUrl = (() => {
 </div>
 
 <script>
+  import {mapRangeOntoAnother} from '../../utils/MathUtils';
+
   (function rippleClickAnimation() {
     const cvButtons = Array.from(document.getElementsByClassName('cv-button'));
 
@@ -70,18 +72,16 @@ const buttonUrl = (() => {
     const minScaleValue = 1;
     const maxScaleValue = 1.5;
 
-    const mappingScaleFactor =
-      (maxScaleValue - minScaleValue) / (maxWidth - minWidth);
-
-    const offset = -minWidth * mappingScaleFactor + minScaleValue;
-
-    const scaleValue = Math.max(
-      Math.min(window.innerWidth * mappingScaleFactor + offset, maxScaleValue),
-      minScaleValue
-    );
-
     cvButtons.forEach((btn) => {
-      (btn as HTMLButtonElement).style.transform = `scale(${scaleValue})`;
+      (btn as HTMLButtonElement).style.transform = `scale(${mapRangeOntoAnother(
+        {
+          valueA: window.innerWidth,
+          minA: minWidth,
+          maxA: maxWidth,
+          minB: minScaleValue,
+          maxB: maxScaleValue,
+        }
+      )})`;
     });
   })();
 </script>

--- a/src/components/website/CvButton.astro
+++ b/src/components/website/CvButton.astro
@@ -18,51 +18,10 @@ const buttonUrl = (() => {
   <a href={buttonUrl}>
     <WebsiteButton label={t('website.home.top-section.cv-button.label')} />
   </a>
-  <div class="ripple-container">
-    <span class="ripple-source"></span>
-  </div>
 </div>
 
 <script>
   import {mapRangeOntoAnother} from '../../utils/MathUtils';
-
-  (function rippleClickAnimation() {
-    const cvButtons = Array.from(document.getElementsByClassName('cv-button'));
-
-    cvButtons.forEach((btn) => {
-      const rippleSource = btn.querySelector('.ripple-source') as
-        | HTMLElement
-        | undefined;
-
-      const rippleContainer = btn.querySelector('.ripple-container') as
-        | HTMLElement
-        | undefined;
-
-      if (!rippleSource || !rippleContainer) {
-        return;
-      }
-
-      btn.addEventListener('click', (event) => {
-        // Remove the animation in case the user clicks and it's still playing
-        rippleContainer.classList.remove('ripple-animation-on');
-        rippleSource?.classList.remove('ripple-animation-on');
-
-        const {pageX, pageY} = event as MouseEvent;
-        const rect = btn.getBoundingClientRect();
-
-        rippleSource.style.top = `${pageY - rect.top}px`;
-        rippleSource.style.left = `${pageX - rect.left}px`;
-
-        rippleContainer?.classList.add('ripple-animation-on');
-        rippleSource?.classList.add('ripple-animation-on');
-      });
-
-      rippleSource.addEventListener('animationend', () => {
-        rippleContainer.classList.remove('ripple-animation-on');
-        rippleSource?.classList.remove('ripple-animation-on');
-      });
-    });
-  })();
 
   (function fluidScaling() {
     const cvButtons = Array.from(document.getElementsByClassName('cv-button'));
@@ -85,56 +44,3 @@ const buttonUrl = (() => {
     });
   })();
 </script>
-
-<style>
-  .cv-button {
-    display: inline-block;
-    position: relative;
-  }
-
-  .ripple-container {
-    position: absolute;
-    inset: 0 0 0 0;
-    overflow: hidden;
-
-    /* We need to lower the z-index so the ripple is behind the button, otherwise it obstructs onhover and onclick events */
-    z-index: -1;
-
-    /* This is necessary to match the scale on button hover */
-    transform: scale(1.1);
-
-    &.ripple-animation-on {
-      z-index: 10;
-    }
-  }
-
-  .ripple-source {
-    position: absolute;
-    display: none;
-    z-index: 11;
-    top: 0;
-    left: 0;
-    width: 7px;
-    height: 7px;
-    border-radius: 50%;
-    box-shadow:
-      0 0 0 2px rgb(255 255 255 / 50%),
-      0 0 0 4px rgb(255 255 255 / 20%);
-
-    &.ripple-animation-on {
-      display: block;
-      animation: shadow-animation 1.6s ease-out;
-    }
-  }
-
-  @keyframes shadow-animation {
-    
-    0% {
-      transform: scale(1);
-    }
-
-    100% {
-      transform: scale(100);
-    }
-  }
-</style>

--- a/src/components/website/WebsiteButton.astro
+++ b/src/components/website/WebsiteButton.astro
@@ -115,7 +115,7 @@ const {label} = Astro.props;
 
     &.ripple-animation-on {
       display: block;
-      animation: grow-animation 1.6s ease-out;
+      animation: grow-animation 1.6s ease-out 0s 1;
     }
   }
 

--- a/src/components/website/WebsiteButton.astro
+++ b/src/components/website/WebsiteButton.astro
@@ -1,9 +1,16 @@
 ---
 interface Props {
   label: string;
+  /**
+   * The maximum font size in rem when the button is in fluid scaling mode.
+   * If not passed or undefined the fluid scaling is disabled.
+   * Useful to make the button bigger depending on the resolution.
+   */
+  fluidMaxFontSizeInRem?: number;
 }
 
 const {label} = Astro.props;
+const cssFluidMaxFontSize = `${Astro.props.fluidMaxFontSizeInRem ?? 1}rem`;
 ---
 
 <button class="website-button" type="button">
@@ -77,7 +84,7 @@ const {label} = Astro.props;
   })();
 </script>
 
-<style>
+<style define:vars={{cssFluidMaxFontSize}}>
   button {
     appearance: none;
     background-color: rgb(var(--accent-color-1));
@@ -86,7 +93,7 @@ const {label} = Astro.props;
     border-style: solid;
     border-radius: 3px;
     font-family: 'Noto Sans', system-ui, sans-serif;
-    font-size: large;
+    font-size: clamp(1rem, 2vw + 0.5rem, var(--cssFluidMaxFontSize));
     padding: 0.5rem;
     cursor: pointer;
     transition: transform ease-in-out 0.1s;

--- a/src/components/website/WebsiteButton.astro
+++ b/src/components/website/WebsiteButton.astro
@@ -48,10 +48,14 @@ const {label} = Astro.props;
         const {clientX, clientY} = event;
         // Get the position and size of the button
         const rect = btn.getBoundingClientRect();
+        const rippleDimensions = {
+          width: 7,
+          height: 7,
+        };
 
         // Calculate the top and left position of the ripple effect center
-        rippleSource!.style.top = `${clientY - rect.top}px`;
-        rippleSource!.style.left = `${clientX - rect.left}px`;
+        rippleSource!.style.top = `${clientY - rect.top - rippleDimensions.height}px`;
+        rippleSource!.style.left = `${clientX - rect.left - rippleDimensions.width}px`;
 
         // Add the animation class to the ripple effect
         rippleSource?.classList.add('ripple-animation-on');

--- a/src/components/website/WebsiteButton.astro
+++ b/src/components/website/WebsiteButton.astro
@@ -115,11 +115,11 @@ const {label} = Astro.props;
 
     &.ripple-animation-on {
       display: block;
-      animation: shadow-animation 1.6s ease-out;
+      animation: grow-animation 1.6s ease-out;
     }
   }
 
-  @keyframes shadow-animation {
+  @keyframes grow-animation {
 
     0% {
       transform: scale(1);

--- a/src/components/website/WebsiteButton.astro
+++ b/src/components/website/WebsiteButton.astro
@@ -97,7 +97,7 @@ const {label} = Astro.props;
   button:hover,
   button:focus,
   button:active {
-    transform: scale(1.1);
+    text-decoration: underline;
   }
 
   .ripple-source {

--- a/src/components/website/WebsiteButton.astro
+++ b/src/components/website/WebsiteButton.astro
@@ -8,7 +8,70 @@ const {label} = Astro.props;
 
 <button class="website-button" type="button">
   {label}
+  <span class="ripple-source"></span>
 </button>
+
+<script>
+  (function rippleClickAnimation() {
+    const buttons = Array.from(
+      document.getElementsByClassName('website-button')
+    ) as HTMLButtonElement[];
+
+    buttons.forEach((btn) => {
+      const rippleSource = btn
+        .getElementsByClassName('ripple-source')
+        .item(0) as HTMLElement | undefined;
+
+      if (!rippleSource) {
+        return;
+      }
+
+      /**
+       * Handles the click event on the button to create
+       * a ripple effect on the clicked location. Delaying
+       * the event bubbling by a brief amount of time.
+       * It only triggers the first time the button is clicked.
+       *
+       * @param {MouseEvent} event - The click event object.
+       */
+      function onClickHandler(event: MouseEvent) {
+        // Prevent the default action of the event,
+        // for now, since we want to play the animation.
+        event.preventDefault();
+        event.stopPropagation();
+
+        // How much time to wait before allowing the button to do
+        // its intended function (so, bubbling the event up).
+        const delayInMs = 150;
+
+        // Get the coordinates where the user clicked in the viewport
+        const {clientX, clientY} = event;
+        // Get the position and size of the button
+        const rect = btn.getBoundingClientRect();
+
+        // Calculate the top and left position of the ripple effect center
+        rippleSource!.style.top = `${clientY - rect.top}px`;
+        rippleSource!.style.left = `${clientX - rect.left}px`;
+
+        // Add the animation class to the ripple effect
+        rippleSource?.classList.add('ripple-animation-on');
+
+        // After a brief delay, remove the click event listener
+        // and click again on the button to trigger any default event
+        setTimeout(() => {
+          btn.removeEventListener('click', onClickHandler);
+          btn.click();
+        }, delayInMs);
+      }
+
+      btn.addEventListener('click', onClickHandler);
+
+      rippleSource.addEventListener('animationend', () => {
+        rippleSource?.classList.remove('ripple-animation-on');
+      });
+    });
+  })();
+</script>
 
 <style>
   button {
@@ -23,11 +86,43 @@ const {label} = Astro.props;
     padding: 0.5rem;
     cursor: pointer;
     transition: transform ease-in-out 0.1s;
+    position: relative;
+    overflow: hidden;
   }
 
   button:hover,
   button:focus,
   button:active {
     transform: scale(1.1);
+  }
+
+  .ripple-source {
+    position: absolute;
+    display: none;
+    z-index: 10;
+    top: 0;
+    left: 0;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    box-shadow:
+      0 0 0 2px rgb(255 255 255 / 50%),
+      0 0 0 4px rgb(255 255 255 / 20%);
+
+    &.ripple-animation-on {
+      display: block;
+      animation: shadow-animation 1.6s ease-out;
+    }
+  }
+
+  @keyframes shadow-animation {
+
+    0% {
+      transform: scale(1);
+    }
+
+    100% {
+      transform: scale(100);
+    }
   }
 </style>

--- a/src/components/website/WebsiteButton.astro
+++ b/src/components/website/WebsiteButton.astro
@@ -71,7 +71,7 @@ const {label} = Astro.props;
       btn.addEventListener('click', onClickHandler);
 
       rippleSource.addEventListener('animationend', () => {
-        rippleSource?.classList.remove('ripple-animation-on');
+        rippleSource.classList.remove('ripple-animation-on');
       });
     });
   })();

--- a/src/components/website/sections/AboutMeSection/AboutMeSection.astro
+++ b/src/components/website/sections/AboutMeSection/AboutMeSection.astro
@@ -1,5 +1,6 @@
 ---
 import {getLangFromUrl, useTranslations} from '../../../../i18n/i18nUtils';
+import CvButton from '../../CvButton.astro';
 import SpanTranslation from '../../SpanTranslation.astro';
 
 const locale = getLangFromUrl(Astro.url);
@@ -12,6 +13,9 @@ const t = useTranslations(locale);
       >{t('website.home.about-me-section.description')}</SpanTranslation
     >
   </p>
+</div>
+<div id="cv-button-container">
+  <CvButton />
 </div>
 
 <style>
@@ -49,7 +53,15 @@ const t = useTranslations(locale);
       color: rgb(var(--accent-color-1));
       position: absolute;
       right: 0;
-      bottom: -2rem;
+      bottom: -3rem;
     }
+  }
+
+  #cv-button-container {
+    width: 100%;
+    display: flex;
+    flex-flow: row nowrap;
+    place-content: center center;
+    margin-top: -1rem;
   }
 </style>

--- a/src/components/website/sections/ProjectsSection/StoreUrlButton.astro
+++ b/src/components/website/sections/ProjectsSection/StoreUrlButton.astro
@@ -55,7 +55,7 @@ const {label, url, disabled = false} = Astro.props;
     &:hover button,
     &:focus button,
     &:active button {
-      transform: scale(1.1);
+      text-decoration: underline;
     }
   }
 </style>

--- a/src/components/website/sections/TopSection/TopSection.astro
+++ b/src/components/website/sections/TopSection/TopSection.astro
@@ -1,6 +1,5 @@
 ---
 import TypewriterText from '../../TypewriterText.astro';
-import CvButton from '../../CvButton.astro';
 import {Image} from 'astro:assets';
 import {getLangFromUrl, useTranslations} from '../../../../i18n/i18nUtils';
 import personPicture from '../../../../assets/images/irian-cv-image.jpg';
@@ -52,20 +51,15 @@ const thirdTypeAnimation = {
           {t('website.home.top-section.subtitle.second-part')}
         </div>
       </TypewriterText>
-      <div id="cv-button-container-desktop">
-        <CvButton />
-      </div>
     </div>
   </div>
+
   <div id="person-picture-container">
     <Image
       id="person-picture"
       src={personPicture}
       alt={t('website.home.top-section.person-image.alt-attribute')}
     />
-  </div>
-  <div id="cv-button-container-mobile">
-    <CvButton />
   </div>
 </div>
 
@@ -133,7 +127,7 @@ const thirdTypeAnimation = {
 
     /* This value is when the layout breaks into 2 rows */
     @media (--top-section-breakdown-max) {
-      margin: 2rem auto;
+      margin: 2rem auto 0 auto;
     }
   }
 
@@ -154,24 +148,5 @@ const thirdTypeAnimation = {
     color: rgb(var(--accent-color-1));
     text-shadow: 2px 2px 6px rgb(var(--accent-color-1) / 70%);
     font-weight: 800;
-  }
-
-  #cv-button-container-desktop {
-    margin-top: 2rem;
-
-    @media (--top-section-breakdown-max) {
-      display: none;
-    }
-  }
-
-  #cv-button-container-mobile {
-    width: 100%;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-
-    @media (--top-section-breakdown-min) {
-      display: none;
-    }
   }
 </style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -154,7 +154,7 @@ const appVersion = import.meta.env.APP_VERSION ?? 'unknown';
     font-size: clamp(2.5rem, 4vw + 1.2rem, 3rem);
     font-weight: 600;
     color: rgb(var(--accent-color-1));
-    margin: 3rem 0 1rem 0;
+    margin: 1rem 0 1rem 0;
     text-shadow: 2px 2px 6px rgb(var(--accent-color-1) / 70%);
     text-align: center;
   }
@@ -168,8 +168,18 @@ const appVersion = import.meta.env.APP_VERSION ?? 'unknown';
     text-align: center;
   }
 
-  .spacer-global {
+  .spacer-global-large {
     width: 1px;
     height: 5rem;
+  }
+
+  .spacer-global-medium {
+    width: 1px;
+    height: 2.5rem;
+  }
+
+  .spacer-global-small {
+    width: 1px;
+    height: 0.5rem;
   }
 </style>

--- a/src/layouts/HomePage.astro
+++ b/src/layouts/HomePage.astro
@@ -25,6 +25,8 @@ const t = useTranslations(locale);
   <main>
     <TopSection />
 
+    <div class="spacer-global-medium" role="presentation"></div>
+
     <h2>
       <SpanTranslation>
         {t('website.home.projects-section-title')}
@@ -33,11 +35,15 @@ const t = useTranslations(locale);
     <div class="heading-underline" role="presentation"></div>
     <ProjectsSection />
 
+    <div class="spacer-global-medium" role="presentation"></div>
+
     <h2 id="about-me-title">
       {t('website.home.about-me-section-title')}
     </h2>
     <div class="heading-underline" role="presentation"></div>
     <AboutMeSection />
+
+    <div class="spacer-global-medium" role="presentation"></div>
 
     <h2 id="contact-title-first-part">
       {t('website.home.contact-title.first-part') + '... '}
@@ -47,7 +53,7 @@ const t = useTranslations(locale);
     </h2>
     <ContactSection />
 
-    <div class="spacer-global" role="presentation"></div>
+    <div class="spacer-global-large" role="presentation"></div>
   </main>
 </BaseLayout>
 

--- a/src/utils/MathUtils.ts
+++ b/src/utils/MathUtils.ts
@@ -1,3 +1,37 @@
 export const getRandomInt = (min: number, max: number) => {
   return Math.floor(Math.random() * (max - min + 1)) + min;
 };
+
+/**
+ * Maps a value from one range onto another range.
+ *
+ * @param {number} minA - minimum value of the input range
+ * @param {number} maxA - maximum value of the input range
+ * @param {number} minB - minimum value of the output range
+ * @param {number} maxB - maximum value of the output range
+ * @param {number} valueA - the value to be mapped
+ * @return {number} the mapped value
+ */
+export function mapRangeOntoAnother({
+  minA,
+  maxA,
+  minB,
+  maxB,
+  valueA,
+}: {
+  minA: number;
+  maxA: number;
+  minB: number;
+  maxB: number;
+  valueA: number;
+}): number {
+  const mappingScaleFactor = (maxB - minB) / (maxA - minA);
+  const offset = -minA * mappingScaleFactor + minB;
+
+  const mappedValue = Math.max(
+    Math.min(valueA * mappingScaleFactor + offset, maxB),
+    minB
+  );
+
+  return mappedValue;
+}


### PR DESCRIPTION
## Changes
- Moved ripple animation into WebsiteButton component. This way we can scale it up and down without destroying the animation.
- Applied button fluid scaling prop
- Moved 'See my resume' button below About Me section. So people see the website and don't skip it prematurely. It preseves the narrative flow of 'I present myself, you see my projects, I explain a little bit more about me, you see my resume, contact me'.
- Replaced sections spaces with spacer elements instead of margins.
- Left unused method inside MathUtils just in case it's useful in the future.