### PR TITLE
Fix gallery back press

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "irian-personal-page",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "irian-personal-page",
-      "version": "1.14.0",
+      "version": "1.14.1",
       "hasInstallScript": true,
       "dependencies": {
         "@astrojs/check": "^0.5.6",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "irian-personal-page",
   "type": "module",
-  "version": "1.14.0",
+  "version": "1.14.1",
   "scripts": {
     "dev": "astro dev",
     "start": "astro dev",

--- a/src/components/website/LightGalleryPressable/LightGalleryPressable.astro
+++ b/src/components/website/LightGalleryPressable/LightGalleryPressable.astro
@@ -59,12 +59,18 @@ const {galleryId, entries} = Astro.props;
       this.addEventListener('click', function () {
         _lightGallery.openGallery(0);
       });
+
+      // Hack to allow phones to close the gallery with the back button
+      this.addEventListener('lgBeforeOpen', () => {
+        window.history.pushState('#lgOpened', '', window.location.href);
+      });
     }
 
     private initLightGallery(id: string) {
       return lightGallery(this, {
         galleryId: id.trim(),
         plugins: [lgHash, lgZoom],
+        hash: true,
         dynamic: true,
         dynamicEl: this.entries,
         download: false,


### PR DESCRIPTION
Gallery wasn't closing with a back button press on phones so I had to use [this hack](https://www.github.com/sachinchoolur/lightGallery/issues/1014#issuecomment-1902613296). There's [an issue of the library opened](https://www.github.com/sachinchoolur/lightGallery/issues/1014), just to keep watching it.

## Changes
- Implemented hack to allow phones close the gallery on back button press. However forwards navigation doesn't reopen the gallery.